### PR TITLE
This commit fixes the 'heroku: not found' error in the deployment wor…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install Heroku CLI
+        run: sudo snap install heroku --classic
+
       - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.13.15
         with:


### PR DESCRIPTION
…kflow.

A new step has been added to the `deploy` job in `.github/workflows/main.yml` to install the Heroku CLI using `snap` before the deployment action is run. This ensures that the Heroku commands are available in the GitHub runner environment.