### PR TITLE
This commit makes the Heroku deployment workflow more robust.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Verify secrets are present
+        run: |
+          if [ -z "${{ secrets.HEROKU_API_KEY }}" ]; then
+            echo "HEROKU_API_KEY secret not set. Please set it in your repository settings."
+            exit 1
+          fi
+          if [ -z "${{ secrets.HEROKU_APP_NAME }}" ]; then
+            echo "HEROKU_APP_NAME secret not set. Please set it in your repository settings."
+            exit 1
+          fi
+          if [ -z "${{ secrets.HEROKU_EMAIL }}" ]; then
+            echo "HEROKU_EMAIL secret not set. Please set it in your repository settings."
+            exit 1
+          fi
+
       - name: Install Heroku CLI
         run: curl https://cli-assets.heroku.com/install.sh | sh
 
@@ -53,6 +68,7 @@ jobs:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
+          dontautocreate: true
         env:
           # This is required to point to the subdirectory containing the app
           HD_APP_BASE: "."


### PR DESCRIPTION
- It adds a step to verify that the required Heroku secrets (`HEROKU_API_KEY`, `HEROKU_APP_NAME`, `HEROKU_EMAIL`) are present before attempting to deploy. This provides a clear error message if they are not set.
- It disables the `autocreate` feature in the deployment action to prevent it from trying to create a new app, which was causing confusing interactive prompts and errors.